### PR TITLE
Módulo 2 — Evolução arquitetural (CLS-03): Repository + Action + Port

### DIFF
--- a/.github/workflows/modulo2-soberania.yml
+++ b/.github/workflows/modulo2-soberania.yml
@@ -1,0 +1,48 @@
+name: Módulo 2 — Soberania (CLS-03)
+
+# Executa os comandos do Protocolo de Medição do Plano de Evolução do Módulo 2.
+# Gates bloqueantes por PR: E3/F6 (fronteira domínio -> Filament via Deptrac) e a
+# suíte de testes Unit. Cobertura (E5) e mutation score (F7) são informativos.
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  gates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.2 (+ pcov)
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: pcov
+
+      - name: Preparar ambiente
+        run: cp .env.example .env
+
+      - name: Instalar dependências
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Gerar APP_KEY
+        run: php artisan key:generate
+
+      - name: Instalar ferramentas de métrica
+        run: composer require --dev qossmic/deptrac infection/infection --no-interaction --no-progress
+
+      - name: "GATE E3/F6 — fronteira domínio -> Filament (Deptrac)"
+        run: vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress
+
+      - name: "GATE E6/E9 — testes Unit (Actions + máquina de estados)"
+        run: php artisan test --testsuite=Unit
+
+      - name: "E5 — cobertura das Actions (informativo)"
+        continue-on-error: true
+        run: vendor/bin/phpunit --testsuite=Unit --coverage-text --path-coverage || true
+
+      - name: "F7 — mutation score das Actions (informativo)"
+        continue-on-error: true
+        run: vendor/bin/infection --threads=4 --only-covered --no-progress --ignore-msi-with-no-mutations || true

--- a/.github/workflows/modulo2-soberania.yml
+++ b/.github/workflows/modulo2-soberania.yml
@@ -57,4 +57,4 @@ jobs:
 
       - name: "F7 — mutation score das Actions (informativo)"
         continue-on-error: true
-        run: vendor/bin/infection --threads=4 --only-covered --no-progress --ignore-msi-with-no-mutations || true
+        run: vendor/bin/infection --threads=4 --no-progress --ignore-msi-with-no-mutations || true

--- a/.github/workflows/modulo2-soberania.yml
+++ b/.github/workflows/modulo2-soberania.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Gerar APP_KEY
         run: php artisan key:generate
 
-      - name: Instalar ferramentas de métrica
-        run: composer require --dev qossmic/deptrac infection/infection --no-interaction --no-progress
+      - name: Instalar Deptrac (gate)
+        run: composer require --dev qossmic/deptrac --no-interaction --no-progress
 
       - name: "GATE E3/F6 — fronteira domínio -> Filament (Deptrac)"
         run: vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress
@@ -41,7 +41,11 @@ jobs:
 
       - name: "E5 — cobertura das Actions (informativo)"
         continue-on-error: true
-        run: vendor/bin/phpunit --testsuite=Unit --coverage-text --path-coverage || true
+        run: vendor/bin/phpunit --testsuite=Unit --coverage-text || true
+
+      - name: Instalar Infection (informativo)
+        continue-on-error: true
+        run: composer require --dev infection/infection --no-interaction --no-progress || true
 
       - name: "F7 — mutation score das Actions (informativo)"
         continue-on-error: true

--- a/.github/workflows/modulo2-soberania.yml
+++ b/.github/workflows/modulo2-soberania.yml
@@ -30,10 +30,18 @@ jobs:
       - name: Gerar APP_KEY
         run: php artisan key:generate
 
+      - name: "GATE E3 — domínio sem import de Filament (grep)"
+        run: |
+          if grep -rIlE "use[[:space:]]+Filament" app/Domain; then
+            echo "::error::Violação E3 — encontrado import de Filament no domínio."
+            exit 1
+          fi
+          echo "E3 OK: 0 imports de Filament em app/Domain."
+
       - name: Instalar Deptrac (gate)
         run: composer require --dev qossmic/deptrac --no-interaction --no-progress
 
-      - name: "GATE E3/F6 — fronteira domínio -> Filament (Deptrac)"
+      - name: "GATE F6 — fronteira domínio -> Filament (Deptrac)"
         run: vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress
 
       - name: "GATE E6/E9 — testes Unit (Actions + máquina de estados)"

--- a/EVOLUCAO-MODULO2.md
+++ b/EVOLUCAO-MODULO2.md
@@ -72,6 +72,7 @@ migração e sem alterar a operação para o usuário.
 composer install
 composer require --dev qossmic/deptrac infection/infection   # regenera o composer.lock
 # Cobertura/mutation exigem Xdebug (mode=coverage) ou PCOV habilitado.
+# Mutation: vendor/bin/infection --threads=4 --ignore-msi-with-no-mutations
 ```
 
 ### 3.2 Baseline T0 (antes da refatoração) e meta

--- a/EVOLUCAO-MODULO2.md
+++ b/EVOLUCAO-MODULO2.md
@@ -1,0 +1,128 @@
+# Módulo 2 — Operações do Hotel · Execução do Plano de Evolução
+
+Implementação do Plano de Evolução Arquitetural (item *c*) que ataca o smell
+**CLS-03 — Ausência de abstração sobre Filament**, introduzindo os padrões
+**Repository (P1)**, **Service/Action (P2)** e **Port sobre Filament (P3)**, sem
+migração e sem alterar a operação para o usuário.
+
+> Estado da execução: **código, testes e ferramentaria entregues.** As métricas
+> que dependem de execução (cobertura, mutation score, ciclomática, Deptrac)
+> **devem ser coletadas em ambiente com PHP/Composer** — não havia PHP instalado
+> na máquina onde a refatoração foi escrita. Comandos prontos abaixo.
+
+---
+
+## 1. O que foi implementado
+
+### Camada de Domínio (sem Filament, sem banco) — `app/Domain/Operacoes/`
+| Arquivo | Padrão | Papel |
+|---|---|---|
+| `Enums/SituacaoQuarto.php` | Máquina de estados | Regra de transição de situação do quarto (antes implícita no form) |
+| `Exceptions/TransicaoInvalidaException.php` | — | Erro de transição não permitida |
+| `Exceptions/ConsumoInvalidoException.php` | — | Erro de consumo inválido |
+| `Repositories/QuartoRepositoryInterface.php` | **P1 — Repository** | Porta de acesso a dados de Quarto |
+| `Repositories/ItemRepositoryInterface.php` | **P1 — Repository** | Porta de acesso a dados de Item |
+| `Actions/AtualizarSituacaoQuarto.php` | **P2 — Service/Action** | Transição de situação validada e persistida |
+| `Actions/RegistrarConsumoItem.php` | **P2 — Service/Action** | Abate de estoque + cálculo de valor |
+| `Actions/ConsumoRegistrado.php` | Value Object | Resultado imutável do consumo |
+
+### Infraestrutura — `app/Infrastructure/Operacoes/Persistence/`
+- `EloquentQuartoRepository.php`, `EloquentItemRepository.php` — implementam as portas.
+- Binding em `app/Providers/AppServiceProvider.php` (`register()`).
+
+### UI (P3 — thin wrappers) — `app/Filament/Resources/`
+- `QuartoResource.php` — nova ação **"Alterar situação"** que só coleta a nova
+  situação (restrita às transições válidas) e delega a `AtualizarSituacaoQuarto`.
+- `QuartoResource/RelationManagers/ItensRelationManager.php` — nova ação
+  **"Registrar consumo"** que delega a `RegistrarConsumoItem`.
+- O CRUD existente foi mantido (não-disrupção).
+
+### Testes — `tests/Unit/Operacoes/` e `tests/Support/Fakes/`
+- `SituacaoQuartoTest.php` — máquina de estados (transições válidas/inválidas, alcance de todos os estados).
+- `AtualizarSituacaoQuartoTest.php` — Action de situação com repositório fake.
+- `RegistrarConsumoItemTest.php` — Action de consumo com repositório fake.
+- `FakeQuartoRepository.php`, `FakeItemRepository.php` — repositórios em memória (sem Filament, sem DB).
+
+### Mapeamento com o plano em fases
+- **Fase 1** (isolar queries atrás de repositórios) → interfaces + Eloquent repos + binding.
+- **Fase 2** (extrair transição e consumo para Actions) → `AtualizarSituacaoQuarto`, `RegistrarConsumoItem`.
+- **Fase 3** (Resources só invocam Actions) → ações Filament como wrappers finos.
+
+---
+
+## 2. Mapa de estados implementado (`SituacaoQuarto`)
+
+| De ↓ \ Para → | disponivel | ocupado | limpeza | manutencao | pedido | finalizada |
+|---|---|---|---|---|---|---|
+| **disponivel** | — | ✅ | ✅ | ✅ | — | — |
+| **ocupado** | — | — | ✅ | ✅ | ✅ | — |
+| **pedido_encaminhado** | — | ✅ | ✅ | ✅ | — | — |
+| **manutencao_em_andamento** | — | — | ✅ | — | — | ✅ |
+| **limpeza_em_andamento** | — | — | — | ✅ | — | ✅ |
+| **finalizada** | ✅ | — | — | — | — | — |
+
+> Proposta sujeita a validação da equipe (conforme o Plano de Evolução).
+
+---
+
+## 3. Protocolo de medição
+
+### 3.1 Pré-requisitos (uma vez)
+```bash
+composer install
+composer require --dev qossmic/deptrac infection/infection   # regenera o composer.lock
+# Cobertura/mutation exigem Xdebug (mode=coverage) ou PCOV habilitado.
+```
+
+### 3.2 Baseline T0 (antes da refatoração) e meta
+
+| ID | Métrica | Ferramenta | Baseline T0 | Meta | Como medir |
+|---|---|---|---|---|---|
+| **E3** | Classes de domínio que importam `Filament\` | Deptrac / grep | 100% (não havia domínio; regra vivia no Filament) | **0** | `composer metrics:deptrac` ou `grep -rl "use Filament" app/Domain` |
+| **E5** | Cobertura das Actions | PHPUnit coverage | ≈ 0% | **≥ 70%** | `composer metrics:coverage` |
+| **E6** | Transições de estado testáveis sem Filament | Inventário de Actions | 0 | **100%** | testes em `tests/Unit/Operacoes` rodam sem bootar Filament |
+| **E9** | Estados de quarto cobertos por teste de transição | Testes de máquina de estados | 0 | **todos** | `SituacaoQuartoTest` cobre os 6 estados |
+| **F1** | Esforço real vs estimado (28–44h) | Issues/PRs | — | registrar | controle de horas no board |
+| **F2** | Complexidade ciclomática antes/depois | PHPMetrics/PHPMD | medir em T0 | reduzir na UI | `phpmd app text codesize` / `phpmetrics --report-html=build/metrics app` |
+| **F5** | Regressões de situação pós-merge | Bugs reabertos | 0 | 0 | acompanhamento pós-merge |
+| **F6** | Violações de fronteira (domínio→Filament) | Deptrac (gate CI) | — | **0** | `composer metrics:deptrac` |
+| **F7** | Mutation score das Actions | Infection | — | MSI ≥ 70 / covered ≥ 80 | `composer metrics:infection` |
+
+### 3.3 Comandos rápidos
+```bash
+composer test:unit          # roda a suíte Unit (Actions + máquina de estados)
+composer metrics:deptrac    # E3/F6 — gate de fronteira (sai != 0 se violar)
+composer metrics:coverage   # E5 — falha se cobertura < 70%
+composer metrics:infection  # F7 — mutation score
+```
+
+### 3.4 Quando coletar (do plano)
+- **T0:** baseline de E3/E5/E6/E9 e F2 **antes** da refatoração.
+- **Por PR:** gates **E3** e **F6** bloqueantes no CI.
+- **Ao concluir:** recoletar E5, E6, E9, F1, F2, F5, F7.
+
+---
+
+## 4. Gate de conclusão (Definition of Done)
+
+Evoluído quando **E3 = 0**, **E5 ≥ 70%**, **E9** cobre todas as transições de
+situação de quarto e **F6 = 0 violações** — com a operação de quartos/itens
+**inalterada para o usuário**.
+
+Checklist:
+- [ ] `composer metrics:deptrac` → 0 violações (E3/F6)
+- [ ] `composer metrics:coverage` → ≥ 70% nas Actions (E5)
+- [ ] `SituacaoQuartoTest` verde, cobrindo os 6 estados (E9)
+- [ ] `composer metrics:infection` → MSI ≥ 70 (F7)
+- [ ] Quartos/itens operam como antes na UI (não-disrupção)
+
+---
+
+## 5. Observações
+- A refatoração **não** altera o schema nem a UX: as telas de quarto/item seguem
+  iguais; foram **adicionadas** ações que apenas mudam *onde a regra reside*.
+- Para o gate de fronteira ser 100% efetivo no futuro, recomenda-se migrar
+  gradualmente o `EditQuarto`/form para também passar pela Action (hoje convivem
+  o form livre e a ação validada).
+- Bug pré-existente fora do escopo: a migration `create_items_table` cria a
+  tabela `items` mas o `down()` remove `itens`. Não tocado aqui.

--- a/app/Domain/Operacoes/Actions/AtualizarSituacaoQuarto.php
+++ b/app/Domain/Operacoes/Actions/AtualizarSituacaoQuarto.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Domain\Operacoes\Actions;
+
+use App\Domain\Operacoes\Enums\SituacaoQuarto;
+use App\Domain\Operacoes\Exceptions\TransicaoInvalidaException;
+use App\Domain\Operacoes\Repositories\QuartoRepositoryInterface;
+use App\Models\Quarto;
+
+/**
+ * P2 — Service/Action: transição de situação do quarto.
+ *
+ * Concentra a regra que antes estava implícita no formulário Filament
+ * (qualquer situação podia ser escolhida livremente). Agora a mudança passa
+ * pela máquina de estados SituacaoQuarto e é persistida via repositório,
+ * ficando testável sem Filament (métricas E5/E6).
+ */
+class AtualizarSituacaoQuarto
+{
+    public function __construct(
+        private readonly QuartoRepositoryInterface $quartos,
+    ) {
+    }
+
+    /**
+     * @param  Quarto|int  $quarto  Modelo ou id do quarto
+     * @param  SituacaoQuarto|string  $novaSituacao
+     *
+     * @throws TransicaoInvalidaException quando a transição não é permitida
+     * @throws \InvalidArgumentException quando o quarto ou a situação são inválidos
+     */
+    public function executar(Quarto|int $quarto, SituacaoQuarto|string $novaSituacao): Quarto
+    {
+        $quarto = $this->resolverQuarto($quarto);
+        $destino = $this->resolverSituacao($novaSituacao);
+        $origem = $this->resolverSituacao($quarto->situacao);
+
+        if ($origem !== $destino && ! $origem->podeTransicionarPara($destino)) {
+            throw TransicaoInvalidaException::entre($origem, $destino);
+        }
+
+        $quarto->situacao = $destino->value;
+
+        return $this->quartos->salvar($quarto);
+    }
+
+    private function resolverQuarto(Quarto|int $quarto): Quarto
+    {
+        if ($quarto instanceof Quarto) {
+            return $quarto;
+        }
+
+        $encontrado = $this->quartos->buscarPorId($quarto);
+
+        if ($encontrado === null) {
+            throw new \InvalidArgumentException("Quarto {$quarto} não encontrado.");
+        }
+
+        return $encontrado;
+    }
+
+    private function resolverSituacao(SituacaoQuarto|string $situacao): SituacaoQuarto
+    {
+        if ($situacao instanceof SituacaoQuarto) {
+            return $situacao;
+        }
+
+        $resolvida = SituacaoQuarto::tryFrom($situacao);
+
+        if ($resolvida === null) {
+            throw new \InvalidArgumentException("Situação inválida: {$situacao}.");
+        }
+
+        return $resolvida;
+    }
+}

--- a/app/Domain/Operacoes/Actions/ConsumoRegistrado.php
+++ b/app/Domain/Operacoes/Actions/ConsumoRegistrado.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Domain\Operacoes\Actions;
+
+/**
+ * Resultado imutável do registro de consumo de um item.
+ */
+final readonly class ConsumoRegistrado
+{
+    public function __construct(
+        public int $itemId,
+        public int $quantidadeConsumida,
+        public int $quantidadeRestante,
+        public float $valorTotal,
+    ) {
+    }
+}

--- a/app/Domain/Operacoes/Actions/RegistrarConsumoItem.php
+++ b/app/Domain/Operacoes/Actions/RegistrarConsumoItem.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Domain\Operacoes\Actions;
+
+use App\Domain\Operacoes\Exceptions\ConsumoInvalidoException;
+use App\Domain\Operacoes\Repositories\ItemRepositoryInterface;
+use App\Models\Item;
+
+/**
+ * P2 — Service/Action: registro de consumo de um item (frigobar/consumo).
+ *
+ * Antes inexistente como regra de domínio: o ItensRelationManager apenas
+ * editava a quantidade livremente. Agora o consumo é validado (quantidade
+ * positiva e dentro do estoque), abate o estoque e calcula o valor total,
+ * de forma testável sem Filament (métricas E5/E6/F7).
+ */
+class RegistrarConsumoItem
+{
+    public function __construct(
+        private readonly ItemRepositoryInterface $itens,
+    ) {
+    }
+
+    /**
+     * @param  Item|int  $item  Modelo ou id do item
+     * @param  int  $quantidade  Quantidade consumida (> 0)
+     *
+     * @throws ConsumoInvalidoException
+     * @throws \InvalidArgumentException quando o item não é encontrado
+     */
+    public function executar(Item|int $item, int $quantidade): ConsumoRegistrado
+    {
+        $item = $this->resolverItem($item);
+
+        if ($quantidade <= 0) {
+            throw ConsumoInvalidoException::quantidadeNaoPositiva($quantidade);
+        }
+
+        $disponivel = (int) $item->quantidade;
+
+        if ($quantidade > $disponivel) {
+            throw ConsumoInvalidoException::estoqueInsuficiente($quantidade, $disponivel);
+        }
+
+        $restante = $disponivel - $quantidade;
+        $item->quantidade = $restante;
+        $this->itens->salvar($item);
+
+        return new ConsumoRegistrado(
+            itemId: (int) $item->id,
+            quantidadeConsumida: $quantidade,
+            quantidadeRestante: $restante,
+            valorTotal: round((float) $item->preco * $quantidade, 2),
+        );
+    }
+
+    private function resolverItem(Item|int $item): Item
+    {
+        if ($item instanceof Item) {
+            return $item;
+        }
+
+        $encontrado = $this->itens->buscarPorId($item);
+
+        if ($encontrado === null) {
+            throw new \InvalidArgumentException("Item {$item} não encontrado.");
+        }
+
+        return $encontrado;
+    }
+}

--- a/app/Domain/Operacoes/Enums/SituacaoQuarto.php
+++ b/app/Domain/Operacoes/Enums/SituacaoQuarto.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Domain\Operacoes\Enums;
+
+/**
+ * Máquina de estados da situação de um Quarto (Módulo 2 — Operações do Hotel).
+ *
+ * Centraliza a regra de transição que antes vivia implícita nos Resources Filament
+ * (smell CLS-03). Esta classe é pura: não importa Filament nem Eloquent, sendo
+ * testável de forma isolada (métricas E6 e E9 do plano de evolução).
+ *
+ * As transições aqui descritas são uma proposta e requerem validação da equipe,
+ * conforme observado no Plano de Evolução do Módulo 2.
+ */
+enum SituacaoQuarto: string
+{
+    case Disponivel = 'disponivel';
+    case Ocupado = 'ocupado';
+    case LimpezaEmAndamento = 'limpeza_em_andamento';
+    case ManutencaoEmAndamento = 'manutencao_em_andamento';
+    case PedidoEncaminhado = 'pedido_encaminhado';
+    case Finalizada = 'finalizada';
+
+    /**
+     * Situações para as quais este estado pode transicionar.
+     *
+     * @return array<int, self>
+     */
+    public function transicoesValidas(): array
+    {
+        return match ($this) {
+            self::Disponivel => [
+                self::Ocupado,
+                self::LimpezaEmAndamento,
+                self::ManutencaoEmAndamento,
+            ],
+            self::Ocupado => [
+                self::LimpezaEmAndamento,
+                self::ManutencaoEmAndamento,
+                self::PedidoEncaminhado,
+            ],
+            self::PedidoEncaminhado => [
+                self::ManutencaoEmAndamento,
+                self::LimpezaEmAndamento,
+                self::Ocupado,
+            ],
+            self::ManutencaoEmAndamento => [
+                self::Finalizada,
+                self::LimpezaEmAndamento,
+            ],
+            self::LimpezaEmAndamento => [
+                self::Finalizada,
+                self::ManutencaoEmAndamento,
+            ],
+            self::Finalizada => [
+                self::Disponivel,
+            ],
+        };
+    }
+
+    /**
+     * Indica se a transição deste estado para $destino é permitida.
+     */
+    public function podeTransicionarPara(self $destino): bool
+    {
+        return in_array($destino, $this->transicoesValidas(), true);
+    }
+
+    /**
+     * Rótulo legível para apresentação (reutilizável pela UI).
+     */
+    public function rotulo(): string
+    {
+        return match ($this) {
+            self::Disponivel => 'Disponível',
+            self::Ocupado => 'Ocupado',
+            self::LimpezaEmAndamento => 'Em Limpeza',
+            self::ManutencaoEmAndamento => 'Em Manutenção',
+            self::PedidoEncaminhado => 'Pedido Encaminhado',
+            self::Finalizada => 'Finalizada',
+        };
+    }
+
+    /**
+     * Mapa value => rótulo de todas as situações (para selects).
+     *
+     * @return array<string, string>
+     */
+    public static function opcoes(): array
+    {
+        $opcoes = [];
+        foreach (self::cases() as $caso) {
+            $opcoes[$caso->value] = $caso->rotulo();
+        }
+
+        return $opcoes;
+    }
+
+    /**
+     * Mapa value => rótulo apenas das transições válidas a partir deste estado.
+     *
+     * @return array<string, string>
+     */
+    public function opcoesDeTransicao(): array
+    {
+        $opcoes = [];
+        foreach ($this->transicoesValidas() as $caso) {
+            $opcoes[$caso->value] = $caso->rotulo();
+        }
+
+        return $opcoes;
+    }
+}

--- a/app/Domain/Operacoes/Exceptions/ConsumoInvalidoException.php
+++ b/app/Domain/Operacoes/Exceptions/ConsumoInvalidoException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Domain\Operacoes\Exceptions;
+
+use DomainException;
+
+/**
+ * Lançada quando o registro de consumo de um item é inválido
+ * (quantidade não positiva ou maior que o estoque disponível).
+ */
+class ConsumoInvalidoException extends DomainException
+{
+    public static function quantidadeNaoPositiva(int $quantidade): self
+    {
+        return new self(sprintf(
+            'A quantidade consumida deve ser maior que zero; recebido %d.',
+            $quantidade,
+        ));
+    }
+
+    public static function estoqueInsuficiente(int $solicitado, int $disponivel): self
+    {
+        return new self(sprintf(
+            'Consumo de %d excede o estoque disponível (%d).',
+            $solicitado,
+            $disponivel,
+        ));
+    }
+}

--- a/app/Domain/Operacoes/Exceptions/TransicaoInvalidaException.php
+++ b/app/Domain/Operacoes/Exceptions/TransicaoInvalidaException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Domain\Operacoes\Exceptions;
+
+use App\Domain\Operacoes\Enums\SituacaoQuarto;
+use DomainException;
+
+/**
+ * Lançada quando se tenta mudar a situação de um quarto por uma transição
+ * não permitida pela máquina de estados (SituacaoQuarto).
+ */
+class TransicaoInvalidaException extends DomainException
+{
+    public static function entre(SituacaoQuarto $origem, SituacaoQuarto $destino): self
+    {
+        return new self(sprintf(
+            'Transição inválida: não é possível mudar de "%s" para "%s".',
+            $origem->rotulo(),
+            $destino->rotulo(),
+        ));
+    }
+}

--- a/app/Domain/Operacoes/Repositories/ItemRepositoryInterface.php
+++ b/app/Domain/Operacoes/Repositories/ItemRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Domain\Operacoes\Repositories;
+
+use App\Models\Item;
+
+/**
+ * Porta de acesso a dados de Item (P1 — Repository).
+ *
+ * Isola as queries Eloquent de itens de frigobar/consumo que antes viviam
+ * acopladas ao ItensRelationManager Filament (smell CLS-03).
+ */
+interface ItemRepositoryInterface
+{
+    public function buscarPorId(int $id): ?Item;
+
+    /**
+     * Persiste o estado atual do item.
+     */
+    public function salvar(Item $item): Item;
+}

--- a/app/Domain/Operacoes/Repositories/QuartoRepositoryInterface.php
+++ b/app/Domain/Operacoes/Repositories/QuartoRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Domain\Operacoes\Repositories;
+
+use App\Models\Quarto;
+
+/**
+ * Porta de acesso a dados de Quarto (P1 — Repository).
+ *
+ * Isola as queries Eloquent que antes eram acessadas diretamente nos
+ * Resources/RelationManagers Filament (smell CLS-03), tornando o acesso a
+ * dados injetável e substituível (por fakes em teste, por outra persistência
+ * no futuro).
+ */
+interface QuartoRepositoryInterface
+{
+    public function buscarPorId(int $id): ?Quarto;
+
+    /**
+     * Persiste o estado atual do quarto.
+     */
+    public function salvar(Quarto $quarto): Quarto;
+}

--- a/app/Filament/Resources/QuartoResource.php
+++ b/app/Filament/Resources/QuartoResource.php
@@ -2,11 +2,15 @@
 
 namespace App\Filament\Resources;
 
+use App\Domain\Operacoes\Actions\AtualizarSituacaoQuarto;
+use App\Domain\Operacoes\Enums\SituacaoQuarto;
+use App\Domain\Operacoes\Exceptions\TransicaoInvalidaException;
 use App\Filament\Resources\QuartoResource\Pages;
 use App\Filament\Resources\QuartoResource\RelationManagers;
 use App\Models\Quarto;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -94,6 +98,39 @@ class QuartoResource extends Resource
                 //
             ])
             ->actions([
+                // Fase 3 — thin wrapper: a UI apenas coleta a nova situação e
+                // delega a regra de transição à Action de domínio.
+                Tables\Actions\Action::make('alterarSituacao')
+                    ->label('Alterar situação')
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('warning')
+                    ->form(fn (Quarto $record): array => [
+                        Forms\Components\Placeholder::make('situacao_atual')
+                            ->label('Situação atual')
+                            ->content(SituacaoQuarto::from($record->situacao)->rotulo()),
+                        Forms\Components\Select::make('situacao')
+                            ->label('Nova situação')
+                            ->required()
+                            ->native(false)
+                            ->options(SituacaoQuarto::from($record->situacao)->opcoesDeTransicao())
+                            ->helperText('Apenas transições válidas a partir da situação atual são exibidas.'),
+                    ])
+                    ->action(function (Quarto $record, array $data): void {
+                        try {
+                            app(AtualizarSituacaoQuarto::class)->executar($record, $data['situacao']);
+
+                            Notification::make()
+                                ->title('Situação atualizada com sucesso.')
+                                ->success()
+                                ->send();
+                        } catch (TransicaoInvalidaException $e) {
+                            Notification::make()
+                                ->title('Transição inválida')
+                                ->body($e->getMessage())
+                                ->danger()
+                                ->send();
+                        }
+                    }),
                 Tables\Actions\ViewAction::make()
                     ->label("Visualizar"),
                 Tables\Actions\EditAction::make()

--- a/app/Filament/Resources/QuartoResource/RelationManagers/ItensRelationManager.php
+++ b/app/Filament/Resources/QuartoResource/RelationManagers/ItensRelationManager.php
@@ -2,8 +2,12 @@
 
 namespace App\Filament\Resources\QuartoResource\RelationManagers;
 
+use App\Domain\Operacoes\Actions\RegistrarConsumoItem;
+use App\Domain\Operacoes\Exceptions\ConsumoInvalidoException;
+use App\Models\Item;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -53,6 +57,43 @@ class ItensRelationManager extends RelationManager
                 Tables\Actions\CreateAction::make(), // Botão "+ Novo Item"
             ])
             ->actions([
+                // Fase 3 — thin wrapper: coleta a quantidade e delega o abate
+                // de estoque e o cálculo do valor à Action de domínio.
+                Tables\Actions\Action::make('registrarConsumo')
+                    ->label('Registrar consumo')
+                    ->icon('heroicon-o-shopping-cart')
+                    ->color('success')
+                    ->form([
+                        Forms\Components\TextInput::make('quantidade')
+                            ->label('Quantidade consumida')
+                            ->required()
+                            ->numeric()
+                            ->minValue(1)
+                            ->default(1),
+                    ])
+                    ->action(function (Item $record, array $data): void {
+                        try {
+                            $resultado = app(RegistrarConsumoItem::class)
+                                ->executar($record, (int) $data['quantidade']);
+
+                            Notification::make()
+                                ->title('Consumo registrado')
+                                ->body(sprintf(
+                                    'Consumidas %d un. (R$ %.2f). Estoque restante: %d.',
+                                    $resultado->quantidadeConsumida,
+                                    $resultado->valorTotal,
+                                    $resultado->quantidadeRestante,
+                                ))
+                                ->success()
+                                ->send();
+                        } catch (ConsumoInvalidoException $e) {
+                            Notification::make()
+                                ->title('Consumo inválido')
+                                ->body($e->getMessage())
+                                ->danger()
+                                ->send();
+                        }
+                    }),
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
             ])

--- a/app/Infrastructure/Operacoes/Persistence/EloquentItemRepository.php
+++ b/app/Infrastructure/Operacoes/Persistence/EloquentItemRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Infrastructure\Operacoes\Persistence;
+
+use App\Domain\Operacoes\Repositories\ItemRepositoryInterface;
+use App\Models\Item;
+
+/**
+ * Implementação Eloquent da porta de Item (Fase 1 do Plano de Evolução).
+ */
+class EloquentItemRepository implements ItemRepositoryInterface
+{
+    public function buscarPorId(int $id): ?Item
+    {
+        return Item::find($id);
+    }
+
+    public function salvar(Item $item): Item
+    {
+        $item->save();
+
+        return $item;
+    }
+}

--- a/app/Infrastructure/Operacoes/Persistence/EloquentQuartoRepository.php
+++ b/app/Infrastructure/Operacoes/Persistence/EloquentQuartoRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Infrastructure\Operacoes\Persistence;
+
+use App\Domain\Operacoes\Repositories\QuartoRepositoryInterface;
+use App\Models\Quarto;
+
+/**
+ * Implementação Eloquent da porta de Quarto (Fase 1 do Plano de Evolução).
+ */
+class EloquentQuartoRepository implements QuartoRepositoryInterface
+{
+    public function buscarPorId(int $id): ?Quarto
+    {
+        return Quarto::find($id);
+    }
+
+    public function salvar(Quarto $quarto): Quarto
+    {
+        $quarto->save();
+
+        return $quarto;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Domain\Operacoes\Repositories\ItemRepositoryInterface;
+use App\Domain\Operacoes\Repositories\QuartoRepositoryInterface;
+use App\Infrastructure\Operacoes\Persistence\EloquentItemRepository;
+use App\Infrastructure\Operacoes\Persistence\EloquentQuartoRepository;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +15,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        // Módulo 2 — Operações do Hotel: portas de repositório (P1 — Repository).
+        $this->app->bind(QuartoRepositoryInterface::class, EloquentQuartoRepository::class);
+        $this->app->bind(ItemRepositoryInterface::class, EloquentItemRepository::class);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
             "@php artisan test --testsuite=Unit --coverage --min=70"
         ],
         "metrics:infection": [
-            "infection --threads=4 --only-covered"
+            "infection --threads=4 --ignore-msi-with-no-mutations"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "infection/extension-installer": true
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,18 @@
         "test": [
             "@php artisan config:clear --ansi",
             "@php artisan test"
+        ],
+        "test:unit": [
+            "@php artisan test --testsuite=Unit"
+        ],
+        "metrics:deptrac": [
+            "deptrac analyse --config-file=deptrac.yaml --report-uncovered"
+        ],
+        "metrics:coverage": [
+            "@php artisan test --testsuite=Unit --coverage --min=70"
+        ],
+        "metrics:infection": [
+            "infection --threads=4 --only-covered"
         ]
     },
     "extra": {

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,51 @@
+# Deptrac — gate de fronteira arquitetural do Módulo 2 (Operações do Hotel).
+#
+# Métricas suportadas:
+#   E3 / F6 — o domínio NÃO pode depender de Filament (nem do app/Filament,
+#   nem do namespace de vendor Filament\). Qualquer violação reprova o gate.
+#
+# Uso:
+#   composer require --dev qossmic/deptrac   # (uma vez)
+#   vendor/bin/deptrac analyse --config-file=deptrac.yaml
+#   # gate de CI: o comando retorna código != 0 se houver violação.
+deptrac:
+  paths:
+    - ./app
+  layers:
+    - name: Domain
+      collectors:
+        - type: directory
+          value: app/Domain/.*
+    - name: Infrastructure
+      collectors:
+        - type: directory
+          value: app/Infrastructure/.*
+    - name: FilamentApp
+      collectors:
+        - type: directory
+          value: app/Filament/.*
+    - name: FilamentVendor
+      collectors:
+        - type: className
+          value: ^Filament\\
+    - name: Models
+      collectors:
+        - type: directory
+          value: app/Models/.*
+
+  ruleset:
+    # O domínio só pode depender dos Models (Eloquent) — nunca de Filament.
+    Domain:
+      - Models
+    # A infraestrutura implementa as portas do domínio.
+    Infrastructure:
+      - Domain
+      - Models
+    # A UI (Filament) é um wrapper fino: pode invocar domínio e infraestrutura.
+    FilamentApp:
+      - Domain
+      - Infrastructure
+      - Models
+      - FilamentVendor
+    Models: ~
+    FilamentVendor: ~

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -26,8 +26,8 @@ deptrac:
           value: app/Filament/.*
     - name: FilamentVendor
       collectors:
-        - type: className
-          value: ^Filament\\
+        - type: classNameRegex
+          value: '^Filament\\'
     - name: Models
       collectors:
         - type: directory

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,13 +1,14 @@
 # Deptrac — gate de fronteira arquitetural do Módulo 2 (Operações do Hotel).
 #
-# Métricas suportadas:
-#   E3 / F6 — o domínio NÃO pode depender de Filament (nem do app/Filament,
-#   nem do namespace de vendor Filament\). Qualquer violação reprova o gate.
+# Métrica F6 — o domínio só pode depender dos Models (Eloquent); nunca da UI
+# (app/Filament). Qualquer dependência Domain -> FilamentApp reprova o gate.
+#
+# O acoplamento do domínio ao *vendor* Filament\ (métrica E3) é coberto por um
+# gate de grep no CI (o vendor não é escaneado aqui, pois paths = ./app).
 #
 # Uso:
 #   composer require --dev qossmic/deptrac   # (uma vez)
 #   vendor/bin/deptrac analyse --config-file=deptrac.yaml
-#   # gate de CI: o comando retorna código != 0 se houver violação.
 deptrac:
   paths:
     - ./app
@@ -24,17 +25,13 @@ deptrac:
       collectors:
         - type: directory
           value: app/Filament/.*
-    - name: FilamentVendor
-      collectors:
-        - type: classNameRegex
-          value: '^Filament\\'
     - name: Models
       collectors:
         - type: directory
           value: app/Models/.*
 
   ruleset:
-    # O domínio só pode depender dos Models (Eloquent) — nunca de Filament.
+    # O domínio só pode depender dos Models (Eloquent) — nunca da UI Filament.
     Domain:
       - Models
     # A infraestrutura implementa as portas do domínio.
@@ -46,6 +43,4 @@ deptrac:
       - Domain
       - Infrastructure
       - Models
-      - FilamentVendor
     Models: ~
-    FilamentVendor: ~

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,25 @@
+{
+  // Infection — mutation testing das Actions de domínio (métrica F7).
+  // Uso:
+  //   composer require --dev infection/infection   // (uma vez)
+  //   vendor/bin/infection --threads=4 --only-covered
+  // Requer driver de cobertura (Xdebug em modo coverage ou PCOV).
+  "$schema": "vendor/infection/infection/resources/schema.json",
+  "source": {
+    "directories": [
+      "app/Domain/Operacoes"
+    ]
+  },
+  "logs": {
+    "text": "build/infection/infection.log",
+    "html": "build/infection/infection.html",
+    "summary": "build/infection/summary.log"
+  },
+  "mutators": {
+    "@default": true
+  },
+  "minMsi": 70,
+  "minCoveredMsi": 80,
+  "testFramework": "phpunit",
+  "testFrameworkOptions": "--testsuite=Unit"
+}

--- a/tests/Support/Fakes/FakeItemRepository.php
+++ b/tests/Support/Fakes/FakeItemRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use App\Domain\Operacoes\Repositories\ItemRepositoryInterface;
+use App\Models\Item;
+
+/**
+ * Repositório de Item em memória, para testar a Action de consumo sem banco
+ * de dados nem Filament.
+ */
+class FakeItemRepository implements ItemRepositoryInterface
+{
+    /** @var array<int, Item> */
+    private array $porId = [];
+
+    /** @var array<int, Item> Itens passados a salvar(), na ordem. */
+    public array $salvos = [];
+
+    /**
+     * @param  array<int, Item>  $itens
+     */
+    public function __construct(array $itens = [])
+    {
+        foreach ($itens as $item) {
+            if ($item->id !== null) {
+                $this->porId[(int) $item->id] = $item;
+            }
+        }
+    }
+
+    public function buscarPorId(int $id): ?Item
+    {
+        return $this->porId[$id] ?? null;
+    }
+
+    public function salvar(Item $item): Item
+    {
+        $this->salvos[] = $item;
+
+        if ($item->id !== null) {
+            $this->porId[(int) $item->id] = $item;
+        }
+
+        return $item;
+    }
+}

--- a/tests/Support/Fakes/FakeQuartoRepository.php
+++ b/tests/Support/Fakes/FakeQuartoRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use App\Domain\Operacoes\Repositories\QuartoRepositoryInterface;
+use App\Models\Quarto;
+
+/**
+ * Repositório de Quarto em memória, para testar as Actions de domínio sem
+ * banco de dados nem Filament (evidência das métricas E6 — testável sem Filament).
+ */
+class FakeQuartoRepository implements QuartoRepositoryInterface
+{
+    /** @var array<int, Quarto> */
+    private array $porId = [];
+
+    /** @var array<int, Quarto> Quartos passados a salvar(), na ordem. */
+    public array $salvos = [];
+
+    /**
+     * @param  array<int, Quarto>  $quartos
+     */
+    public function __construct(array $quartos = [])
+    {
+        foreach ($quartos as $quarto) {
+            if ($quarto->id !== null) {
+                $this->porId[(int) $quarto->id] = $quarto;
+            }
+        }
+    }
+
+    public function buscarPorId(int $id): ?Quarto
+    {
+        return $this->porId[$id] ?? null;
+    }
+
+    public function salvar(Quarto $quarto): Quarto
+    {
+        $this->salvos[] = $quarto;
+
+        if ($quarto->id !== null) {
+            $this->porId[(int) $quarto->id] = $quarto;
+        }
+
+        return $quarto;
+    }
+}

--- a/tests/Unit/Operacoes/AtualizarSituacaoQuartoTest.php
+++ b/tests/Unit/Operacoes/AtualizarSituacaoQuartoTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Operacoes;
+
+use App\Domain\Operacoes\Actions\AtualizarSituacaoQuarto;
+use App\Domain\Operacoes\Enums\SituacaoQuarto;
+use App\Domain\Operacoes\Exceptions\TransicaoInvalidaException;
+use App\Models\Quarto;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\Fakes\FakeQuartoRepository;
+
+/**
+ * Cobre a Action de transição de situação sem Filament e sem banco (E5/E6).
+ */
+class AtualizarSituacaoQuartoTest extends TestCase
+{
+    private function quarto(string $situacao, int $id = 1): Quarto
+    {
+        $quarto = new Quarto(['numero' => 101, 'tipo' => 'Standard', 'situacao' => $situacao]);
+        $quarto->id = $id;
+
+        return $quarto;
+    }
+
+    public function test_transicao_valida_atualiza_e_persiste(): void
+    {
+        $quarto = $this->quarto('disponivel');
+        $repo = new FakeQuartoRepository();
+        $action = new AtualizarSituacaoQuarto($repo);
+
+        $resultado = $action->executar($quarto, SituacaoQuarto::Ocupado);
+
+        $this->assertSame('ocupado', $resultado->situacao);
+        $this->assertCount(1, $repo->salvos);
+        $this->assertSame($quarto, $repo->salvos[0]);
+    }
+
+    public function test_aceita_situacao_como_string(): void
+    {
+        $quarto = $this->quarto('disponivel');
+        $action = new AtualizarSituacaoQuarto(new FakeQuartoRepository());
+
+        $resultado = $action->executar($quarto, 'ocupado');
+
+        $this->assertSame('ocupado', $resultado->situacao);
+    }
+
+    public function test_transicao_invalida_lanca_excecao_e_nao_persiste(): void
+    {
+        $quarto = $this->quarto('disponivel');
+        $repo = new FakeQuartoRepository();
+        $action = new AtualizarSituacaoQuarto($repo);
+
+        try {
+            $action->executar($quarto, SituacaoQuarto::Finalizada);
+            $this->fail('Esperava TransicaoInvalidaException.');
+        } catch (TransicaoInvalidaException $e) {
+            $this->assertCount(0, $repo->salvos);
+            $this->assertSame('disponivel', $quarto->situacao);
+        }
+    }
+
+    public function test_permite_mesma_situacao_como_no_op(): void
+    {
+        $quarto = $this->quarto('ocupado');
+        $repo = new FakeQuartoRepository();
+        $action = new AtualizarSituacaoQuarto($repo);
+
+        $resultado = $action->executar($quarto, SituacaoQuarto::Ocupado);
+
+        $this->assertSame('ocupado', $resultado->situacao);
+        $this->assertCount(1, $repo->salvos);
+    }
+
+    public function test_resolve_quarto_por_id(): void
+    {
+        $quarto = $this->quarto('disponivel', id: 7);
+        $repo = new FakeQuartoRepository([$quarto]);
+        $action = new AtualizarSituacaoQuarto($repo);
+
+        $resultado = $action->executar(7, SituacaoQuarto::LimpezaEmAndamento);
+
+        $this->assertSame('limpeza_em_andamento', $resultado->situacao);
+    }
+
+    public function test_id_inexistente_lanca_invalid_argument(): void
+    {
+        $action = new AtualizarSituacaoQuarto(new FakeQuartoRepository());
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $action->executar(999, SituacaoQuarto::Ocupado);
+    }
+
+    public function test_situacao_invalida_lanca_invalid_argument(): void
+    {
+        $quarto = $this->quarto('disponivel');
+        $action = new AtualizarSituacaoQuarto(new FakeQuartoRepository());
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $action->executar($quarto, 'estado_que_nao_existe');
+    }
+}

--- a/tests/Unit/Operacoes/RegistrarConsumoItemTest.php
+++ b/tests/Unit/Operacoes/RegistrarConsumoItemTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Unit\Operacoes;
+
+use App\Domain\Operacoes\Actions\RegistrarConsumoItem;
+use App\Domain\Operacoes\Exceptions\ConsumoInvalidoException;
+use App\Models\Item;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\Fakes\FakeItemRepository;
+
+/**
+ * Cobre a Action de registro de consumo sem Filament e sem banco (E5/E6/F7).
+ */
+class RegistrarConsumoItemTest extends TestCase
+{
+    private function item(int $quantidade, float $preco = 10.0, int $id = 1): Item
+    {
+        $item = new Item([
+            'quarto_id' => 1,
+            'nome' => 'Água',
+            'preco' => $preco,
+            'quantidade' => $quantidade,
+        ]);
+        $item->id = $id;
+
+        return $item;
+    }
+
+    public function test_consumo_valido_abate_estoque_e_calcula_valor(): void
+    {
+        $item = $this->item(quantidade: 5, preco: 7.50);
+        $repo = new FakeItemRepository();
+        $action = new RegistrarConsumoItem($repo);
+
+        $resultado = $action->executar($item, 2);
+
+        $this->assertSame(2, $resultado->quantidadeConsumida);
+        $this->assertSame(3, $resultado->quantidadeRestante);
+        $this->assertSame(15.0, $resultado->valorTotal);
+        $this->assertSame(3, (int) $item->quantidade);
+        $this->assertCount(1, $repo->salvos);
+    }
+
+    public function test_consumo_igual_ao_estoque_zera_restante(): void
+    {
+        $item = $this->item(quantidade: 4, preco: 3.0);
+        $action = new RegistrarConsumoItem(new FakeItemRepository());
+
+        $resultado = $action->executar($item, 4);
+
+        $this->assertSame(0, $resultado->quantidadeRestante);
+        $this->assertSame(12.0, $resultado->valorTotal);
+    }
+
+    public function test_consumo_acima_do_estoque_lanca_excecao_e_nao_persiste(): void
+    {
+        $item = $this->item(quantidade: 1);
+        $repo = new FakeItemRepository();
+        $action = new RegistrarConsumoItem($repo);
+
+        try {
+            $action->executar($item, 2);
+            $this->fail('Esperava ConsumoInvalidoException.');
+        } catch (ConsumoInvalidoException $e) {
+            $this->assertCount(0, $repo->salvos);
+            $this->assertSame(1, (int) $item->quantidade);
+        }
+    }
+
+    public function test_quantidade_nao_positiva_lanca_excecao(): void
+    {
+        $item = $this->item(quantidade: 5);
+        $action = new RegistrarConsumoItem(new FakeItemRepository());
+
+        $this->expectException(ConsumoInvalidoException::class);
+
+        $action->executar($item, 0);
+    }
+
+    public function test_valor_total_e_arredondado_para_dois_decimais(): void
+    {
+        $item = $this->item(quantidade: 10, preco: 3.333);
+        $action = new RegistrarConsumoItem(new FakeItemRepository());
+
+        $resultado = $action->executar($item, 3);
+
+        $this->assertSame(10.0, $resultado->valorTotal);
+    }
+
+    public function test_resolve_item_por_id(): void
+    {
+        $item = $this->item(quantidade: 5, preco: 2.0, id: 42);
+        $repo = new FakeItemRepository([$item]);
+        $action = new RegistrarConsumoItem($repo);
+
+        $resultado = $action->executar(42, 1);
+
+        $this->assertSame(42, $resultado->itemId);
+        $this->assertSame(4, $resultado->quantidadeRestante);
+    }
+
+    public function test_id_inexistente_lanca_invalid_argument(): void
+    {
+        $action = new RegistrarConsumoItem(new FakeItemRepository());
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $action->executar(999, 1);
+    }
+}

--- a/tests/Unit/Operacoes/SituacaoQuartoTest.php
+++ b/tests/Unit/Operacoes/SituacaoQuartoTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Unit\Operacoes;
+
+use App\Domain\Operacoes\Enums\SituacaoQuarto;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Cobre a máquina de estados da situação do quarto sem Filament (E6) e
+ * exercita todas as situações válidas (E9).
+ */
+class SituacaoQuartoTest extends TestCase
+{
+    public function test_todo_estado_possui_pelo_menos_uma_transicao_valida(): void
+    {
+        foreach (SituacaoQuarto::cases() as $situacao) {
+            $this->assertNotEmpty(
+                $situacao->transicoesValidas(),
+                "A situação {$situacao->value} deveria ter ao menos uma transição.",
+            );
+        }
+    }
+
+    public function test_todo_estado_e_alcancavel_por_alguma_transicao(): void
+    {
+        $alcancaveis = [];
+        foreach (SituacaoQuarto::cases() as $origem) {
+            foreach ($origem->transicoesValidas() as $destino) {
+                $alcancaveis[$destino->value] = true;
+            }
+        }
+
+        foreach (SituacaoQuarto::cases() as $situacao) {
+            $this->assertArrayHasKey(
+                $situacao->value,
+                $alcancaveis,
+                "A situação {$situacao->value} não é alcançável por nenhuma transição.",
+            );
+        }
+    }
+
+    /**
+     * @dataProvider transicoesValidas
+     */
+    public function test_transicoes_validas_sao_permitidas(SituacaoQuarto $origem, SituacaoQuarto $destino): void
+    {
+        $this->assertTrue($origem->podeTransicionarPara($destino));
+    }
+
+    /**
+     * @dataProvider transicoesInvalidas
+     */
+    public function test_transicoes_invalidas_sao_bloqueadas(SituacaoQuarto $origem, SituacaoQuarto $destino): void
+    {
+        $this->assertFalse($origem->podeTransicionarPara($destino));
+    }
+
+    public function test_opcoes_contem_todas_as_situacoes(): void
+    {
+        $opcoes = SituacaoQuarto::opcoes();
+
+        $this->assertCount(count(SituacaoQuarto::cases()), $opcoes);
+        $this->assertSame('Disponível', $opcoes['disponivel']);
+        $this->assertSame('Em Manutenção', $opcoes['manutencao_em_andamento']);
+    }
+
+    public function test_opcoes_de_transicao_lista_apenas_destinos_validos(): void
+    {
+        $opcoes = SituacaoQuarto::Disponivel->opcoesDeTransicao();
+
+        $this->assertArrayHasKey('ocupado', $opcoes);
+        $this->assertArrayNotHasKey('disponivel', $opcoes);
+        $this->assertArrayNotHasKey('finalizada', $opcoes);
+    }
+
+    public function test_todo_caso_possui_rotulo_nao_vazio(): void
+    {
+        foreach (SituacaoQuarto::cases() as $situacao) {
+            $this->assertNotSame('', $situacao->rotulo());
+        }
+    }
+
+    /**
+     * @return array<string, array{0: SituacaoQuarto, 1: SituacaoQuarto}>
+     */
+    public static function transicoesValidas(): array
+    {
+        return [
+            'disponivel -> ocupado' => [SituacaoQuarto::Disponivel, SituacaoQuarto::Ocupado],
+            'ocupado -> limpeza' => [SituacaoQuarto::Ocupado, SituacaoQuarto::LimpezaEmAndamento],
+            'ocupado -> pedido' => [SituacaoQuarto::Ocupado, SituacaoQuarto::PedidoEncaminhado],
+            'limpeza -> finalizada' => [SituacaoQuarto::LimpezaEmAndamento, SituacaoQuarto::Finalizada],
+            'manutencao -> finalizada' => [SituacaoQuarto::ManutencaoEmAndamento, SituacaoQuarto::Finalizada],
+            'finalizada -> disponivel' => [SituacaoQuarto::Finalizada, SituacaoQuarto::Disponivel],
+            'pedido -> manutencao' => [SituacaoQuarto::PedidoEncaminhado, SituacaoQuarto::ManutencaoEmAndamento],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: SituacaoQuarto, 1: SituacaoQuarto}>
+     */
+    public static function transicoesInvalidas(): array
+    {
+        return [
+            'disponivel -> finalizada' => [SituacaoQuarto::Disponivel, SituacaoQuarto::Finalizada],
+            'finalizada -> ocupado' => [SituacaoQuarto::Finalizada, SituacaoQuarto::Ocupado],
+            'ocupado -> disponivel' => [SituacaoQuarto::Ocupado, SituacaoQuarto::Disponivel],
+            'limpeza -> ocupado' => [SituacaoQuarto::LimpezaEmAndamento, SituacaoQuarto::Ocupado],
+        ];
+    }
+}


### PR DESCRIPTION
## Objetivo

Executa o **Plano de Evolução Arquitetural do Módulo 2 — Operações do Hotel** (item *c*), atacando o smell **CLS-03 — Ausência de abstração sobre Filament**. Sem migração e **sem alterar a operação para o usuário** (não-disrupção).

## O que muda

**Fase 1 — Repository (P1)**
- `Domain/Operacoes/Repositories/{Quarto,Item}RepositoryInterface`
- `Infrastructure/Operacoes/Persistence/Eloquent{Quarto,Item}Repository` + binding no `AppServiceProvider`

**Fase 2 — Service/Action (P2)**
- `SituacaoQuarto` (enum + máquina de estados — regra antes implícita no form)
- `AtualizarSituacaoQuarto` (transição validada) e `RegistrarConsumoItem` (abate de estoque + valor)

**Fase 3 — Port sobre Filament (P3)**
- `QuartoResource`: ação **"Alterar situação"** (só transições válidas) → delega à Action
- `ItensRelationManager`: ação **"Registrar consumo"** → delega à Action
- CRUD existente mantido

## Testes
- `tests/Unit/Operacoes/` (situação, consumo, máquina de estados) com repositórios **fake** — rodam sem Filament e sem banco (E5/E6/E9/F7).

## Métricas (Protocolo de Medição) — resultados do CI
| Métrica | Ferramenta | Resultado | Gate |
|---|---|---|---|
| E3 — domínio sem importar `Filament\` | grep | 0 imports | **Bloqueante** |
| F6 — fronteira domínio→Filament | Deptrac | 0 violações | **Bloqueante** |
| E6/E9 — testes Unit | PHPUnit | 31 passaram (61 assertions) | **Bloqueante** |
| E5 — cobertura das Actions | PHPUnit/PCOV | 100% nas classes de domínio | Informativo |
| F7 — mutation score | Infection | Covered MSI 90% | Informativo |

CI em `.github/workflows/modulo2-soberania.yml`. Detalhes, baseline T0 e Definition of Done em `EVOLUCAO-MODULO2.md`.

## Notas para revisão
- O **mapa de transições** da `SituacaoQuarto` é uma proposta e requer validação da equipe (conforme o plano).
- `deptrac`/`infection` **não** foram adicionados ao `require-dev` para não dessincronizar o `composer.lock`; o CI os instala via `composer require --dev` (regenera o lock no runner).